### PR TITLE
add(database): versioning

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,20 +2,34 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/vague2k/rummage/pkg/config"
 	"github.com/vague2k/rummage/pkg/database"
 )
 
 func NewRootCmd(db database.RummageDbInterface) *cobra.Command {
+	conf := config.SetVersions()
 	rootCmd := &cobra.Command{
 		Use:     "rummage [command]",
-		Version: "3.0.4",
+		Version: conf.Rummage.Version,
 		Short:   "A smart wrapper around 'go get'",
 		Run: func(cmd *cobra.Command, args []string) {
+			dbVersionFlag, err := cmd.Flags().GetBool("apiver")
+			if err != nil {
+				panic(err)
+			}
+
+			if dbVersionFlag {
+				cmd.Printf("rummage database api version %s\n", db.Version())
+				return
+			}
+
 			if err := cmd.Help(); err != nil {
 				cmd.PrintErr(err)
 			}
 		},
 	}
+
+	rootCmd.Flags().BoolP("apiver", "a", false, "outputs the current version of the rummage database api")
 
 	rootCmd.AddCommand(newPopulateCmd(db))
 	rootCmd.AddCommand(newQueryCmd(db))

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 )
 
 require (
+	github.com/BurntSushi/toml v1.4.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0=
+github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,21 @@
+package config
+
+import (
+	"github.com/BurntSushi/toml"
+)
+
+type config struct {
+	Rummage struct {
+		Version      string `toml:"version"`
+		DbApiVersion string `toml:"dbApiVersion"`
+	} `toml:"rummage"`
+}
+
+func SetVersions() *config {
+	var conf config
+	if _, err := toml.DecodeFile("./pkg/config/version.toml", &conf); err != nil {
+		panic(err)
+	}
+
+	return &conf
+}

--- a/pkg/config/version.toml
+++ b/pkg/config/version.toml
@@ -1,0 +1,3 @@
+[rummage]
+version="v3.0.4"
+dbApiVersion="v2.0.0" 

--- a/pkg/config/version.toml
+++ b/pkg/config/version.toml
@@ -1,3 +1,3 @@
 [rummage]
-version="v3.0.4"
+version="v3.0.5"
 dbApiVersion="v2.0.0" 

--- a/pkg/database/db.go
+++ b/pkg/database/db.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	_ "github.com/mattn/go-sqlite3"
+	"github.com/vague2k/rummage/pkg/config"
 	"github.com/vague2k/rummage/utils"
 )
 
@@ -19,6 +20,7 @@ import (
 //
 // because it makes my life writing tests very easy.
 type RummageDbInterface interface {
+	Version() string
 	AddItem(entry string) (*RummageItem, error)
 	AddMultiItems(entries ...string) ([]*RummageItem, int, error)
 	Close()
@@ -38,6 +40,7 @@ type RummageDb struct {
 	Sqlite   *sql.DB // Pointer to the underlying sqlite database
 	Dir      string  // The parent directory of the database
 	FilePath string  // the database path
+	version  string
 }
 
 // Initializes the rummage db, returning a pointer to the db instance.
@@ -78,13 +81,20 @@ func Init(path string) (*RummageDb, error) {
 		return nil, fmt.Errorf("could not create 'items' table in rummage db: \n%s", err)
 	}
 
+	conf := config.SetVersions()
+
 	instance := &RummageDb{
 		Sqlite:   database,
 		Dir:      dir,
 		FilePath: dbFile,
+		version:  conf.Rummage.DbApiVersion,
 	}
 
 	return instance, nil
+}
+
+func (r *RummageDb) Version() string {
+	return r.version
 }
 
 func (r *RummageDb) Close() {


### PR DESCRIPTION
### Purpose?
This pr attempts to separate versioning of the `rummage cli tool` and the internal database api. 

### Why?
Trying to encapsulate version information in 1 semver number makes it unclear as to what should be regarded as major or minor update.

`rummage version 3.0.0` was a essentially a rewrite of the whole program, meaning the database interface was also rewritten. As it stands, the database versions starts at `v2.0.0` for this reason.