### PR TITLE
Query rework

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,4 +22,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.60
+          version: v1.64.5

--- a/README.md
+++ b/README.md
@@ -8,10 +8,8 @@
 
 ## Installation
 
-If you would like to install the latest version of a tag, substitue the version number for `@latest`
-
 ```
-go install github.com/vague2k/rummage@3.0.2
+go install github.com/vague2k/rummage@3.1.0
 ```
 
 ## Getting Started

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ## Installation
 
 ```
-go install github.com/vague2k/rummage@3.1.0
+go install github.com/vague2k/rummage
 ```
 
 ## Getting Started

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -6,7 +6,6 @@ import (
 	"github.com/vague2k/rummage/pkg/database"
 )
 
-// TODO: add docs for new functionality / tests
 func newQueryCmd(db database.RummageDbInterface) *cobra.Command {
 	queryCmd := &cobra.Command{
 		Use:   "query",

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -17,7 +17,7 @@ func newQueryCmd(db database.RummageDbInterface) *cobra.Command {
 		},
 	}
 
-	queryCmd.Flags().IntP("quantity", "q", 10, "")
+	queryCmd.Flags().IntP("quantity", "q", 10, "The amount of entry matches to display in the output")
 
 	return queryCmd
 }

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -6,6 +6,7 @@ import (
 	"github.com/vague2k/rummage/pkg/database"
 )
 
+// TODO: add docs for new functionality / tests
 func newQueryCmd(db database.RummageDbInterface) *cobra.Command {
 	queryCmd := &cobra.Command{
 		Use:   "query",
@@ -17,9 +18,7 @@ func newQueryCmd(db database.RummageDbInterface) *cobra.Command {
 		},
 	}
 
-	queryCmd.Flags().BoolP("exact", "e", false, "Query the database to find an entry using an exact search, instead of by highest score")
-	queryCmd.Flags().BoolP("score", "s", false, "Display the query's score")
-	queryCmd.Flags().BoolP("last-accessed", "l", false, "Display the last accessed timestamp of the query in Unix seconds")
+	queryCmd.Flags().IntP("quantity", "p", 10, "")
 
 	return queryCmd
 }

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -17,7 +17,7 @@ func newQueryCmd(db database.RummageDbInterface) *cobra.Command {
 		},
 	}
 
-	queryCmd.Flags().IntP("quantity", "p", 10, "")
+	queryCmd.Flags().IntP("quantity", "q", 10, "")
 
 	return queryCmd
 }

--- a/cmd/query_test.go
+++ b/cmd/query_test.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -8,43 +10,32 @@ import (
 )
 
 func TestQuery(t *testing.T) {
-	t.Run("Returns highest score entry", func(t *testing.T) {
+	t.Run("Default amount of sorted matches", func(t *testing.T) {
 		db := testutils.InMemDb(t)
-		_, _, err := db.AddMultiItems("github.com/gorilla/mux", "github.com/user/mux")
-		assert.NoError(t, err)
-		_, err = db.UpdateItem("github.com/gorilla/mux", 2.0, 1)
-		assert.NoError(t, err)
+
+		for i := range 10 {
+			if i == 0 {
+				continue
+			}
+			fakePkg := fmt.Sprintf("github.com/user%d/mux", i)
+
+			_, err := db.AddItem(fakePkg)
+			assert.NoError(t, err)
+
+			_, err = db.UpdateItem(fakePkg, float64(i), int64(i))
+			assert.NoError(t, err)
+		}
 
 		cmd := NewRootCmd(db)
 		actual := testutils.Execute(cmd, "query", "mux")
 
-		assert.Equal(t, "github.com/gorilla/mux \n", actual)
-	})
+		s := strings.Builder{}
+		for i := 9; i > 0; i-- {
+			s.WriteString(fmt.Sprintf("%d : %.4f : github.com/user%d/mux\n", int64(i), float64(i), i))
+		}
+		expected := s.String() + "\n"
 
-	t.Run("Returns highest score entry and score", func(t *testing.T) {
-		db := testutils.InMemDb(t)
-		_, _, err := db.AddMultiItems("github.com/gorilla/mux", "github.com/user/mux")
-		assert.NoError(t, err)
-		_, err = db.UpdateItem("github.com/gorilla/mux", 2.0, 1)
-		assert.NoError(t, err)
-
-		cmd := NewRootCmd(db)
-		actual := testutils.Execute(cmd, "query", "--score", "mux")
-
-		assert.Equal(t, "github.com/gorilla/mux 2.00 \n", actual)
-	})
-
-	t.Run("Returns highest score entry, score and last-accessed", func(t *testing.T) {
-		db := testutils.InMemDb(t)
-		_, _, err := db.AddMultiItems("github.com/gorilla/mux", "github.com/user/mux")
-		assert.NoError(t, err)
-		_, err = db.UpdateItem("github.com/gorilla/mux", 2.0, 1725341448)
-		assert.NoError(t, err)
-
-		cmd := NewRootCmd(db)
-		actual := testutils.Execute(cmd, "query", "--score", "--last-accessed", "mux")
-
-		assert.Equal(t, "github.com/gorilla/mux 2.00 1725341448 \n", actual)
+		assert.Equal(t, expected, actual)
 	})
 
 	t.Run("Errors if no match was found", func(t *testing.T) {
@@ -53,158 +44,5 @@ func TestQuery(t *testing.T) {
 		actual := testutils.Execute(cmd, "query", "mux")
 
 		assert.Equal(t, "no match found with the given arguement mux\n", actual)
-	})
-}
-
-func TestMultiQuery(t *testing.T) {
-	t.Run("Returns multiple highest score entries", func(t *testing.T) {
-		db := testutils.InMemDb(t)
-		_, _, err := db.AddMultiItems("github.com/gorilla/mux", "github.com/user/mux", "github.com/labstack/echo/v4", "github.com/user/echo")
-		assert.NoError(t, err)
-		_, err = db.UpdateItem("github.com/gorilla/mux", 2.0, 1)
-		assert.NoError(t, err)
-		_, err = db.UpdateItem("github.com/labstack/echo/v4", 2.0, 1)
-		assert.NoError(t, err)
-
-		cmd := NewRootCmd(db)
-		actual := testutils.Execute(cmd, "query", "mux", "echo")
-
-		assert.Equal(t, "github.com/gorilla/mux \ngithub.com/labstack/echo/v4 \n", actual)
-	})
-
-	t.Run("Returns multiple highest score entries and scores", func(t *testing.T) {
-		db := testutils.InMemDb(t)
-		_, _, err := db.AddMultiItems("github.com/gorilla/mux", "github.com/user/mux", "github.com/labstack/echo/v4", "github.com/user/echo")
-		assert.NoError(t, err)
-		_, err = db.UpdateItem("github.com/gorilla/mux", 2.0, 1)
-		assert.NoError(t, err)
-		_, err = db.UpdateItem("github.com/labstack/echo/v4", 2.0, 1)
-		assert.NoError(t, err)
-
-		cmd := NewRootCmd(db)
-		actual := testutils.Execute(cmd, "query", "--score", "mux", "echo")
-
-		assert.Equal(t, "github.com/gorilla/mux 2.00 \ngithub.com/labstack/echo/v4 2.00 \n", actual)
-	})
-
-	t.Run("Returns multiple highest score entries, scores and last-accessed fields", func(t *testing.T) {
-		db := testutils.InMemDb(t)
-		_, _, err := db.AddMultiItems("github.com/gorilla/mux", "github.com/user/mux", "github.com/labstack/echo/v4", "github.com/user/echo")
-		assert.NoError(t, err)
-		_, err = db.UpdateItem("github.com/gorilla/mux", 2.0, 1725341448)
-		assert.NoError(t, err)
-		_, err = db.UpdateItem("github.com/labstack/echo/v4", 2.0, 1725341448)
-		assert.NoError(t, err)
-
-		cmd := NewRootCmd(db)
-		actual := testutils.Execute(cmd, "query", "--score", "--last-accessed", "mux", "echo")
-
-		assert.Equal(t, "github.com/gorilla/mux 2.00 1725341448 \ngithub.com/labstack/echo/v4 2.00 1725341448 \n", actual)
-	})
-
-	t.Run("Errors if no multiple matches were found", func(t *testing.T) {
-		db := testutils.InMemDb(t)
-		cmd := NewRootCmd(db)
-		actual := testutils.Execute(cmd, "query", "mux", "echo")
-
-		assert.Equal(t, "no match found with the given arguement mux\nno match found with the given arguement echo\n", actual)
-	})
-}
-
-func TestExactQuery(t *testing.T) {
-	t.Run("Returns exact entry", func(t *testing.T) {
-		db := testutils.InMemDb(t)
-		_, _, err := db.AddMultiItems("github.com/gorilla/mux", "github.com/user/mux")
-		assert.NoError(t, err)
-
-		cmd := NewRootCmd(db)
-		actual := testutils.Execute(cmd, "query", "mux")
-
-		assert.Equal(t, "github.com/gorilla/mux \n", actual)
-	})
-
-	t.Run("Returns exact entry and score", func(t *testing.T) {
-		db := testutils.InMemDb(t)
-		_, _, err := db.AddMultiItems("github.com/gorilla/mux", "github.com/user/mux")
-		assert.NoError(t, err)
-
-		cmd := NewRootCmd(db)
-		actual := testutils.Execute(cmd, "query", "--score", "mux")
-
-		assert.Equal(t, "github.com/gorilla/mux 1.00 \n", actual)
-	})
-
-	t.Run("Returns exact entry, score and last accessed", func(t *testing.T) {
-		db := testutils.InMemDb(t)
-		_, _, err := db.AddMultiItems("github.com/gorilla/mux", "github.com/user/mux")
-		assert.NoError(t, err)
-		_, err = db.UpdateItem("github.com/gorilla/mux", 1.0, 1725341448)
-		assert.NoError(t, err)
-		_, err = db.UpdateItem("github.com/user/mux", 1.0, 1725341448)
-		assert.NoError(t, err)
-
-		cmd := NewRootCmd(db)
-		actual := testutils.Execute(cmd, "query", "--score", "--last-accessed", "mux")
-
-		assert.Equal(t, "github.com/gorilla/mux 1.00 1725341448 \n", actual)
-	})
-
-	t.Run("Errors if no exact match was found", func(t *testing.T) {
-		db := testutils.InMemDb(t)
-		cmd := NewRootCmd(db)
-		actual := testutils.Execute(cmd, "query", "--exact", "mux")
-
-		assert.Equal(t, "no match found with the given arguement mux\n", actual)
-	})
-}
-
-func TestMultiExactQuery(t *testing.T) {
-	t.Run("Returns multiple exact entries", func(t *testing.T) {
-		db := testutils.InMemDb(t)
-		_, _, err := db.AddMultiItems("github.com/gorilla/mux", "github.com/user/mux", "github.com/labstack/echo/v4", "github.com/user/echo")
-		assert.NoError(t, err)
-
-		cmd := NewRootCmd(db)
-		actual := testutils.Execute(cmd, "query", "mux", "echo")
-
-		assert.Equal(t, "github.com/gorilla/mux \ngithub.com/labstack/echo/v4 \n", actual)
-	})
-
-	t.Run("Returns multiple exact entries and scores", func(t *testing.T) {
-		db := testutils.InMemDb(t)
-		_, _, err := db.AddMultiItems("github.com/gorilla/mux", "github.com/user/mux", "github.com/labstack/echo/v4", "github.com/user/echo")
-		assert.NoError(t, err)
-
-		cmd := NewRootCmd(db)
-		actual := testutils.Execute(cmd, "query", "--exact", "--score", "mux", "echo")
-
-		assert.Equal(t, "github.com/gorilla/mux 1.00 \ngithub.com/labstack/echo/v4 1.00 \n", actual)
-	})
-
-	t.Run("Returns multiple exact entries, scores and last-accessed", func(t *testing.T) {
-		db := testutils.InMemDb(t)
-		_, _, err := db.AddMultiItems("github.com/gorilla/mux", "github.com/user/mux", "github.com/labstack/echo/v4", "github.com/user/echo")
-		assert.NoError(t, err)
-		_, err = db.UpdateItem("github.com/gorilla/mux", 1.0, 1725341448)
-		assert.NoError(t, err)
-		_, err = db.UpdateItem("github.com/user/mux", 1.0, 1725341448)
-		assert.NoError(t, err)
-		_, err = db.UpdateItem("github.com/labstack/echo/v4", 1.0, 1725341448)
-		assert.NoError(t, err)
-		_, err = db.UpdateItem("github.com/user/echo", 1.0, 1725341448)
-		assert.NoError(t, err)
-
-		cmd := NewRootCmd(db)
-		actual := testutils.Execute(cmd, "query", "--exact", "--score", "--last-accessed", "mux", "echo")
-
-		assert.Equal(t, "github.com/gorilla/mux 1.00 1725341448 \ngithub.com/labstack/echo/v4 1.00 1725341448 \n", actual)
-	})
-
-	t.Run("Errors if no multiple exact matches were found", func(t *testing.T) {
-		db := testutils.InMemDb(t)
-		cmd := NewRootCmd(db)
-		actual := testutils.Execute(cmd, "query", "--exact", "mux", "echo")
-
-		assert.Equal(t, "no match found with the given arguement mux\nno match found with the given arguement echo\n", actual)
 	})
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,24 +2,30 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/vague2k/rummage/pkg/commands/utils"
 	"github.com/vague2k/rummage/pkg/config"
 	"github.com/vague2k/rummage/pkg/database"
 )
 
 func NewRootCmd(db database.RummageDbInterface) *cobra.Command {
-	conf := config.SetVersions()
 	rootCmd := &cobra.Command{
-		Use:     "rummage [command]",
-		Version: conf.Rummage.Version,
-		Short:   "A smart wrapper around 'go get'",
+		Use:   "rummage [command]",
+		Short: "A smart wrapper around 'go get'",
 		Run: func(cmd *cobra.Command, args []string) {
-			dbVersionFlag, err := cmd.Flags().GetBool("apiver")
+			flags, err := utils.GetBoolFlags(cmd, "version", "apiver")
 			if err != nil {
 				panic(err)
 			}
 
-			if dbVersionFlag {
+			if flags["apiver"] {
 				cmd.Printf("rummage database api version %s\n", db.Version())
+				return
+			}
+
+			ver := config.SetVersions().Rummage.Version
+
+			if flags["version"] {
+				cmd.Printf("rummage version %s\n", ver)
 				return
 			}
 
@@ -30,6 +36,7 @@ func NewRootCmd(db database.RummageDbInterface) *cobra.Command {
 	}
 
 	rootCmd.Flags().BoolP("apiver", "a", false, "outputs the current version of the rummage database api")
+	rootCmd.Flags().BoolP("version", "v", false, "outputs the current rummage version")
 
 	rootCmd.AddCommand(newPopulateCmd(db))
 	rootCmd.AddCommand(newQueryCmd(db))

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,20 +2,34 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
+	"github.com/vague2k/rummage/pkg/config"
 	"github.com/vague2k/rummage/pkg/database"
 )
 
 func NewRootCmd(db database.RummageDbInterface) *cobra.Command {
+	conf := config.SetVersions()
 	rootCmd := &cobra.Command{
 		Use:     "rummage [command]",
-		Version: "3.0.4",
+		Version: conf.Rummage.Version,
 		Short:   "A smart wrapper around 'go get'",
 		Run: func(cmd *cobra.Command, args []string) {
+			dbVersionFlag, err := cmd.Flags().GetBool("apiver")
+			if err != nil {
+				panic(err)
+			}
+
+			if dbVersionFlag {
+				cmd.Printf("rummage database api version %s\n", db.Version())
+				return
+			}
+
 			if err := cmd.Help(); err != nil {
 				cmd.PrintErr(err)
 			}
 		},
 	}
+
+	rootCmd.Flags().BoolP("apiver", "a", false, "outputs the current version of the rummage database api")
 
 	rootCmd.AddCommand(newPopulateCmd(db))
 	rootCmd.AddCommand(newQueryCmd(db))

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,6 +17,10 @@ func NewRootCmd(db database.RummageDbInterface) *cobra.Command {
 				panic(err)
 			}
 
+			// the "Version" field in the cobra.Command struct can't be used because
+			// that would cause me to pass in "config" as a param affecting tests.
+			//
+			// right now it's not worth refactoring all that code when I could just do this, and just mark both flags as mutually exclusive
 			if flags["apiver"] {
 				cmd.Printf("rummage database api version %s\n", db.Version())
 				return
@@ -37,6 +41,7 @@ func NewRootCmd(db database.RummageDbInterface) *cobra.Command {
 
 	rootCmd.Flags().BoolP("apiver", "a", false, "outputs the current version of the rummage database api")
 	rootCmd.Flags().BoolP("version", "v", false, "outputs the current rummage version")
+	rootCmd.MarkFlagsMutuallyExclusive("version", "apiver")
 
 	rootCmd.AddCommand(newPopulateCmd(db))
 	rootCmd.AddCommand(newQueryCmd(db))

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 )
 
 require (
+	github.com/BurntSushi/toml v1.4.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,13 @@ module github.com/vague2k/rummage
 go 1.23.0
 
 require (
+	github.com/BurntSushi/toml v1.4.0
 	github.com/mattn/go-sqlite3 v1.14.24
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.10.0
 )
 
 require (
-	github.com/BurntSushi/toml v1.4.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/BurntSushi/toml v1.4.0 h1:kuoIxZQy2WRRk1pttg9asf+WVv6tWQuBNVmK8+nqPr0=
+github.com/BurntSushi/toml v1.4.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/pkg/commands/query.go
+++ b/pkg/commands/query.go
@@ -8,12 +8,10 @@ import (
 	"github.com/vague2k/rummage/pkg/database"
 )
 
-// The Query command lets a user query the database against an arg to return the entry.
-// By default with no flags the query will search based on highest score, if the "--exact" flag is true,
-// it will simply do a strings.contains search.
+// The Query command lets a user query the database against an arg to output a list of
+// entries (10 by default) sorted by score.
 //
-// You can view other info like the entry's score and last-accessed field by setting the respective flags,
-// "--score", "--last-accessed"
+// the quantity of matches in the output can be changed with the "--quantity" flag
 func Query(cmd *cobra.Command, arg string, db database.RummageDbInterface) {
 	quantityFlag, err := cmd.Flags().GetInt("quantity")
 	if err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -4,15 +4,15 @@ import (
 	"github.com/BurntSushi/toml"
 )
 
-type config struct {
+type Config struct {
 	Rummage struct {
 		Version      string `toml:"version"`
 		DbApiVersion string `toml:"dbApiVersion"`
 	} `toml:"rummage"`
 }
 
-func SetVersions() *config {
-	var conf config
+func SetVersions() *Config {
+	var conf Config
 	if _, err := toml.DecodeFile("./pkg/config/version.toml", &conf); err != nil {
 		panic(err)
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,21 @@
+package config
+
+import (
+	"github.com/BurntSushi/toml"
+)
+
+type config struct {
+	Rummage struct {
+		Version      string `toml:"version"`
+		DbApiVersion string `toml:"dbApiVersion"`
+	} `toml:"rummage"`
+}
+
+func SetVersions() *config {
+	var conf config
+	if _, err := toml.DecodeFile("./pkg/config/version.toml", &conf); err != nil {
+		panic(err)
+	}
+
+	return &conf
+}

--- a/pkg/config/version.toml
+++ b/pkg/config/version.toml
@@ -1,0 +1,3 @@
+[rummage]
+version="v3.0.5"
+dbApiVersion="v2.0.0" 

--- a/pkg/config/version.toml
+++ b/pkg/config/version.toml
@@ -1,3 +1,3 @@
 [rummage]
-version="v3.0.5"
-dbApiVersion="v2.0.0" 
+version="v3.1.0"
+dbApiVersion="v3.0.0" 

--- a/pkg/database/db.go
+++ b/pkg/database/db.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	_ "github.com/mattn/go-sqlite3"
+	"github.com/vague2k/rummage/pkg/config"
 	"github.com/vague2k/rummage/utils"
 )
 
@@ -19,6 +20,7 @@ import (
 //
 // because it makes my life writing tests very easy.
 type RummageDbInterface interface {
+	Version() string
 	AddItem(entry string) (*RummageItem, error)
 	AddMultiItems(entries ...string) ([]*RummageItem, int, error)
 	Close()
@@ -38,6 +40,7 @@ type RummageDb struct {
 	Sqlite   *sql.DB // Pointer to the underlying sqlite database
 	Dir      string  // The parent directory of the database
 	FilePath string  // the database path
+	version  string
 }
 
 // Initializes the rummage db, returning a pointer to the db instance.
@@ -78,13 +81,20 @@ func Init(path string) (*RummageDb, error) {
 		return nil, fmt.Errorf("could not create 'items' table in rummage db: \n%s", err)
 	}
 
+	conf := config.SetVersions()
+
 	instance := &RummageDb{
 		Sqlite:   database,
 		Dir:      dir,
 		FilePath: dbFile,
+		version:  conf.Rummage.DbApiVersion,
 	}
 
 	return instance, nil
+}
+
+func (r *RummageDb) Version() string {
+	return r.version
 }
 
 func (r *RummageDb) Close() {

--- a/pkg/database/db.go
+++ b/pkg/database/db.go
@@ -15,6 +15,9 @@ import (
 	"github.com/vague2k/rummage/utils"
 )
 
+// why does this interface exist even though there's only 1 implementation
+//
+// because it makes my life writing tests very easy.
 type RummageDbInterface interface {
 	AddItem(entry string) (*RummageItem, error)
 	AddMultiItems(entries ...string) ([]*RummageItem, int, error)
@@ -232,6 +235,9 @@ func (r *RummageDb) EntryWithHighestScore(substr string) (*RummageItem, error) {
 	return highestMatch, nil
 }
 
+// Finds top n matches in the database based on a substr, sorted in descending by score
+//
+// No matches is treated as an error
 func (r *RummageDb) FindTopNMatches(substr string, n int) ([]*RummageItem, error) {
 	items, err := r.ListItems()
 	if err != nil {

--- a/pkg/database/db.go
+++ b/pkg/database/db.go
@@ -47,15 +47,20 @@ type RummageDb struct {
 //
 // Init() also makes sure the "items" table exists.
 func Init(path string) (*RummageDb, error) {
+	var ver string
 	if path == "" {
 		dataDir := utils.UserDataDir()
 		path = dataDir
+
+		conf := config.SetVersions()
+		ver = conf.Rummage.DbApiVersion
 	}
 
 	var dir string
 	var dbFile string
 	if path == ":memory:" {
 		dbFile = ":memory:"
+		ver = ""
 	} else {
 		dir = filepath.Join(path, "rummage")
 		dbFile = filepath.Join(dir, "rummage.db")
@@ -81,13 +86,11 @@ func Init(path string) (*RummageDb, error) {
 		return nil, fmt.Errorf("could not create 'items' table in rummage db: \n%s", err)
 	}
 
-	conf := config.SetVersions()
-
 	instance := &RummageDb{
 		Sqlite:   database,
 		Dir:      dir,
 		FilePath: dbFile,
-		version:  conf.Rummage.DbApiVersion,
+		version:  ver,
 	}
 
 	return instance, nil

--- a/pkg/database/db_test.go
+++ b/pkg/database/db_test.go
@@ -9,17 +9,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/vague2k/rummage/pkg/database"
+	"github.com/vague2k/rummage/testutils"
 )
 
 // Spin up an in memory db (since we're using sqlite3) for quick testing
 func inMemDb(t *testing.T) *database.RummageDb {
-	r, err := database.Init(":memory:")
-	assert.NoError(t, err)
-	t.Cleanup(func() {
-		r.Close()
-		r = nil
-	})
-	return r
+	return testutils.InMemDb(t)
 }
 
 // Actual test cases should are in seperate t.Run() instances, unless the test is reasonable concise enough to

--- a/pkg/database/db_test.go
+++ b/pkg/database/db_test.go
@@ -1,6 +1,7 @@
 package database_test
 
 import (
+	"fmt"
 	"path/filepath"
 	"regexp"
 	"testing"
@@ -216,23 +217,38 @@ func TestEntryWithHighestScore(t *testing.T) {
 	})
 }
 
-func TestFindExactMatch(t *testing.T) {
+func TestFindTopNMatches(t *testing.T) {
 	r := inMemDb(t)
-	_, _, err := r.AddMultiItems("github.com/gorilla/mux", "github.com/user/mux", "github.com/doesntexist/mux")
-	assert.NoError(t, err)
+	for i := range 10 {
+		fakePkg := fmt.Sprintf("github.com/user%d/mux", i)
 
-	t.Run("Can find first occurence of substr (exact match)", func(t *testing.T) {
-		item, err := r.FindExactMatch("mux")
+		_, err := r.AddItem(fakePkg)
 		assert.NoError(t, err)
-		assert.NotNil(t, item)
 
-		assert.Equal(t, "github.com/gorilla/mux", item.Entry)
-		assert.Equal(t, 1.0, item.Score)
-		assert.Equal(t, time.Now().Unix(), item.LastAccessed)
+		_, err = r.UpdateItem(fakePkg, float64(i), int64(i))
+		assert.NoError(t, err)
+	}
+
+	t.Run("Returns slice of items sorted by score", func(t *testing.T) {
+		items, err := r.FindTopNMatches("mux", 10)
+		assert.NoError(t, err)
+
+		for i := len(items); i > len(items); i-- {
+			fakePkg := fmt.Sprintf("github.com/user%d/mux", i-1)
+			assert.Equal(t, float64(i-1), items[i].Score)
+			assert.Equal(t, fakePkg, items[i].Entry)
+		}
+		for i, item := range items {
+			fakePkg := fmt.Sprintf("github.com/user%d/mux", len(items)-i-1)
+			assert.Equal(t, float64(len(items)-i-1), item.Score)
+			assert.Equal(t, fakePkg, item.Entry)
+		}
 	})
 
+	// items still exist in the test db instance at this point
 	t.Run("Errors if no exact match was found", func(t *testing.T) {
-		item, err := r.FindExactMatch("doesnotexist")
+		item, err := r.FindTopNMatches("doesnotexist", 10)
+		assert.Error(t, err)
 		assert.ErrorContains(t, err, "no match found with the given arguement doesnotexist")
 		assert.Nil(t, item)
 	})


### PR DESCRIPTION
# Changed behavior

### Old output
The `query` command as `v3.0.5` only shows 1 match, as an entry with no other fields or information like this...
<img width="600" alt="Screenshot 2025-02-27 at 1 18 00 AM" src="https://github.com/user-attachments/assets/15067f6b-3b27-42cb-9fb6-436deb6100db" />

### New output
While the command's implementation is still the same, it now outputs the top matches (default amount is 10 but this can be changed with the `--quantity` flag), sorted in descending order based on score like this...
<img width="600" alt="Screenshot 2025-02-27 at 1 18 15 AM" src="https://github.com/user-attachments/assets/a08339e0-0a68-43f2-bb90-186693014633" />

This new behavior assumes you want to know every there is to know about a specific match, and shows you multiple matches in a sorted, easily parsable format, which is what I originally had in mind for the `query` command.
